### PR TITLE
Introduced React Router and new pages including count, history, home,…

### DIFF
--- a/babykicks/package-lock.json
+++ b/babykicks/package-lock.json
@@ -20,6 +20,7 @@
         "firebase": "^10.12.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.11",
         "web-vitals": "^2.1.4"
@@ -4489,6 +4490,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+      "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -16370,6 +16379,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
+      "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
+      "dependencies": {
+        "@remix-run/router": "1.16.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
+      "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
+      "dependencies": {
+        "@remix-run/router": "1.16.1",
+        "react-router": "6.23.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/babykicks/package.json
+++ b/babykicks/package.json
@@ -15,6 +15,7 @@
     "firebase": "^10.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.11",
     "web-vitals": "^2.1.4"

--- a/babykicks/src/index.js
+++ b/babykicks/src/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import "./index.css";
+import { BrowserRouter } from "react-router-dom";
 import App from "../src/routes/home/App";
 import reportWebVitals from "./reportWebVitals";
 import { UserProvider } from "./contexts/user.context";
@@ -8,9 +8,11 @@ import { UserProvider } from "./contexts/user.context";
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <UserProvider>
-      <App />
-    </UserProvider>
+    <BrowserRouter>
+      <UserProvider>
+        <App />
+      </UserProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );
 

--- a/babykicks/src/pages/count.js
+++ b/babykicks/src/pages/count.js
@@ -1,0 +1,31 @@
+import React from "react";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+
+function Count() {
+  const drawerWidth = 240;
+
+  return (
+    <>
+      <Box sx={{ display: "flex" }}>
+        <Box
+          component="nav"
+          sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
+          aria-label="mailbox folders"
+        ></Box>
+        <Box
+          component="main"
+          sx={{
+            flexGrow: 1,
+            p: 3,
+            width: { sm: `calc(100% - ${drawerWidth}px)` },
+          }}
+        >
+          <Typography paragraph>Count baby kicks!</Typography>
+        </Box>
+      </Box>
+    </>
+  );
+}
+
+export default Count;

--- a/babykicks/src/pages/history.js
+++ b/babykicks/src/pages/history.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+
+function History() {
+  const drawerWidth = 240;
+  return (
+    <>
+      <Box sx={{ display: "flex" }}>
+        <Box
+          component="nav"
+          sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
+          aria-label="mailbox folders"
+        ></Box>
+        <Box
+          component="main"
+          sx={{
+            flexGrow: 1,
+            p: 3,
+            width: { sm: `calc(100% - ${drawerWidth}px)` },
+          }}
+        >
+          <Typography paragraph>History page</Typography>
+        </Box>
+      </Box>
+    </>
+  );
+}
+
+export default History;

--- a/babykicks/src/pages/home.js
+++ b/babykicks/src/pages/home.js
@@ -1,11 +1,13 @@
 import React from "react";
+import { Outlet } from "react-router-dom";
+import ResponsiveDrawer from "../routes/navigation/navbar.component";
 
 function Home() {
   return (
-    <div>
-      <h1>Home Page</h1>
-      
-    </div>
+    <>
+      <ResponsiveDrawer />
+      <Outlet />
+    </>
   );
 }
 

--- a/babykicks/src/pages/profile.js
+++ b/babykicks/src/pages/profile.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+
+function Profile() {
+  const drawerWidth = 240;
+  return (
+    <>
+      <Box sx={{ display: "flex" }}>
+        <Box
+          component="nav"
+          sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
+          aria-label="mailbox folders"
+        ></Box>
+        <Box
+          component="main"
+          sx={{
+            flexGrow: 1,
+            p: 3,
+            width: { sm: `calc(100% - ${drawerWidth}px)` },
+          }}
+        >
+          <Typography paragraph>Profile page</Typography>
+        </Box>
+      </Box>
+    </>
+  );
+}
+
+export default Profile;

--- a/babykicks/src/pages/settings.js
+++ b/babykicks/src/pages/settings.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+
+function Settings() {
+  const drawerWidth = 240;
+  return (
+    <>
+      <Box sx={{ display: "flex" }}>
+        <Box
+          component="nav"
+          sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
+          aria-label="mailbox folders"
+        ></Box>
+        <Box
+          component="main"
+          sx={{
+            flexGrow: 1,
+            p: 3,
+            width: { sm: `calc(100% - ${drawerWidth}px)` },
+          }}
+        >
+          <Typography paragraph>Settings page</Typography>
+        </Box>
+      </Box>
+    </>
+  );
+}
+
+export default Settings;

--- a/babykicks/src/routes/home/App.js
+++ b/babykicks/src/routes/home/App.js
@@ -1,17 +1,25 @@
-import SignIn from "../../routes/googleSignIn";
-import ResponsiveDrawer from "../navigation/navbar.component";
-import { UserContext } from "../../contexts/user.context";
-import React, { useContext } from "react";
+import React from "react";
+import { Routes, Route } from "react-router-dom";
+// import { UserContext } from "../../contexts/user.context";
+// import SignIn from "../../routes/googleSignIn";
+import Home from "../../pages/home";
+import Count from "../../pages/count";
+import Settings from "../../pages/settings";
+import History from "../../pages/history";
+import Profile from "../../pages/profile";
 
 function App() {
-  const { currentUser } = useContext(UserContext);
   return (
-    <div className="App">
-      <header className="App-header">
-        <div>{<ResponsiveDrawer />}</div>
-        <div>{currentUser ? <h1>Sign Out</h1> : <SignIn />}</div>
-      </header>
-    </div>
+    <>
+      <Routes>
+        <Route path="/" element={<Home />}>
+          <Route path="count" element={<Count />} />
+          <Route path="settings" element={<Settings />} />
+          <Route path="history" element={<History />} />
+          <Route path="profile" element={<Profile />} />
+        </Route>
+      </Routes>
+    </>
   );
 }
 

--- a/babykicks/src/routes/navigation/navbar.component.js
+++ b/babykicks/src/routes/navigation/navbar.component.js
@@ -1,5 +1,5 @@
-import * as React from "react";
-// import { Outlet, Link } from "react-router-dom";
+import React, { useContext } from "react";
+import { UserContext } from "../../contexts/user.context";
 
 import PropTypes from "prop-types";
 import AppBar from "@mui/material/AppBar";
@@ -14,6 +14,7 @@ import PregnantWomanIcon from "@mui/icons-material/PregnantWoman";
 import AccessTimeOutlinedIcon from "@mui/icons-material/AccessTimeOutlined";
 import AccountCircleOutlinedIcon from "@mui/icons-material/AccountCircleOutlined";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
+import LoginIcon from "@mui/icons-material/Login";
 
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -27,6 +28,8 @@ import Typography from "@mui/material/Typography";
 const drawerWidth = 240;
 
 function ResponsiveDrawer(props) {
+  const { currentUser } = useContext(UserContext);
+
   const { window } = props;
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [isClosing, setIsClosing] = React.useState(false);
@@ -35,8 +38,9 @@ function ResponsiveDrawer(props) {
     <HomeIcon />,
     <PregnantWomanIcon />,
     <AccessTimeOutlinedIcon />,
+    <LoginIcon />,
   ];
-  const linkListA = ["Home", "Count the kicks", "History"];
+  const linkListA = ["Home", "Count the kicks", "History", "Sign in"];
 
   const iconListB = [<AccountCircleOutlinedIcon />, <SettingsOutlinedIcon />];
   const linkListB = ["Profile", "Settings"];
@@ -61,6 +65,7 @@ function ResponsiveDrawer(props) {
       <Toolbar />
       <Divider />
       <List>
+        {currentUser ? <h1>Sign out</h1> : ""}
         {linkListA.map((text, index) => (
           <ListItem key={text} disablePadding>
             <ListItemButton>
@@ -161,35 +166,6 @@ function ResponsiveDrawer(props) {
         }}
       >
         <Toolbar />
-        <Typography paragraph>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Rhoncus
-          dolor purus non enim praesent elementum facilisis leo vel. Risus at
-          ultrices mi tempus imperdiet. Semper risus in hendrerit gravida rutrum
-          quisque non tellus. Convallis convallis tellus id interdum velit
-          laoreet id donec ultrices. Odio morbi quis commodo odio aenean sed
-          adipiscing. Amet nisl suscipit adipiscing bibendum est ultricies
-          integer quis. Cursus euismod quis viverra nibh cras. Metus vulputate
-          eu scelerisque felis imperdiet proin fermentum leo. Mauris commodo
-          quis imperdiet massa tincidunt. Cras tincidunt lobortis feugiat
-          vivamus at augue. At augue eget arcu dictum varius duis at consectetur
-          lorem. Velit sed ullamcorper morbi tincidunt. Lorem donec massa sapien
-          faucibus et molestie ac.
-        </Typography>
-        <Typography paragraph>
-          Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
-          ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar
-          elementum integer enim neque volutpat ac tincidunt. Ornare suspendisse
-          sed nisi lacus sed viverra tellus. Purus sit amet volutpat consequat
-          mauris. Elementum eu facilisis sed odio morbi. Euismod lacinia at quis
-          risus sed vulputate odio. Morbi tincidunt ornare massa eget egestas
-          purus viverra accumsan in. In hendrerit gravida rutrum quisque non
-          tellus orci ac. Pellentesque nec nam aliquam sem et tortor. Habitant
-          morbi tristique senectus et. Adipiscing elit duis tristique
-          sollicitudin nibh sit. Ornare aenean euismod elementum nisi quis
-          eleifend. Commodo viverra maecenas accumsan lacus vel facilisis. Nulla
-          posuere sollicitudin aliquam ultrices sagittis orci a.
-        </Typography>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Description

This pull request introduces React Router to our application for efficient client-side routing. Additionally, new pages (`History`, `Count`, `Settings`, and `Profile`) have been created using Material UI for consistent styling across the application.

## Related Issue(s)

This pull request addresses issue #10 

## Proposed Changes

1. Installed `react-router-dom` for routing functionalities.
- Configured `BrowserRouter` in the main App component.
- Created a `Routes` component to manage route definitions and navigation.

2. New Pages Created:
- `History`
- `Count`
- `Settings`
- `Profile`

3. Material UI Integration
- Applied Material UI components and styling to the new pages.
- Ensured consistent theming and responsiveness across all pages.

## Additional Notes 
- Navigation links on navigation bar needs to be set up to access these pages