### PR TITLE
Feature/#24 Save baby kick counts onto Firestore

### DIFF
--- a/babykicks/src/components/googleSignIn.js
+++ b/babykicks/src/components/googleSignIn.js
@@ -1,8 +1,8 @@
 import React, { useContext } from "react";
 import { UserContext } from "../contexts/user.context";
-import { auth, provider, db } from "../utils/firebase/config";
+import { ProfileContext } from "../contexts/profile.context";
+import { auth, provider } from "../utils/firebase/config";
 import { signInWithPopup } from "firebase/auth";
-import { doc, setDoc } from "firebase/firestore";
 
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -13,19 +13,22 @@ import LoginIcon from "@mui/icons-material/Login";
 
 function SignIn() {
   const { setCurrentUser } = useContext(UserContext);
+  const { setCurrentProfile } = useContext(ProfileContext);
 
   const handleClick = async () => {
     try {
       const data = await signInWithPopup(auth, provider);
       setCurrentUser(data);
-      localStorage.setItem("email", data.user.email);
-      console.log(`user is signed in successfully. User is now ${data}`);
+      // localStorage.setItem("email", data.user.email);
 
-      await setDoc(doc(db, "user", data.user.email), {
-        name: data.user.displayName,
-        email: data.user.email,
-        displayPicture: data.user.photoURL,
-      });
+      if (data) {
+        const userProfileData = {
+          name: data.user.displayName,
+          email: data.user.email,
+          displayPicture: data.user.photoURL,
+        };
+        setCurrentProfile(userProfileData);
+      }
     } catch (error) {
       console.error(`error signing in with popup: ${error}`);
     }

--- a/babykicks/src/contexts/profile.context.jsx
+++ b/babykicks/src/contexts/profile.context.jsx
@@ -1,0 +1,20 @@
+import { createContext, useState } from "react";
+
+export const ProfileContext = createContext({
+  currentProfile: null,
+  setCurrentProfile: () => null,
+});
+
+export const ProfileProvider = ({ children }) => {
+  const [currentProfile, setCurrentProfile] = useState({
+    name: "",
+    email: "",
+    displayPicture: "",
+    history: [],
+    // serverTimestamp: "",
+  });
+  const value = { currentProfile, setCurrentProfile };
+  return (
+    <ProfileContext.Provider value={value}>{children}</ProfileContext.Provider>
+  );
+};

--- a/babykicks/src/contexts/user.context.jsx
+++ b/babykicks/src/contexts/user.context.jsx
@@ -6,7 +6,13 @@ export const UserContext = createContext({
 });
 
 export const UserProvider = ({ children }) => {
-  const [currentUser, setCurrentUser] = useState(null);
+  const [currentUser, setCurrentUser] = useState({
+    name: "",
+    email: "",
+    displayPicture: "",
+    history: [],
+    serverTimestamp: "",
+  });
   const value = { currentUser, setCurrentUser };
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
 };

--- a/babykicks/src/index.js
+++ b/babykicks/src/index.js
@@ -5,15 +5,18 @@ import App from "../src/routes/home/App";
 import reportWebVitals from "./reportWebVitals";
 import { UserProvider } from "./contexts/user.context";
 import { CountProvider } from "./contexts/count.context";
+import { ProfileProvider } from "./contexts/profile.context";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
       <UserProvider>
-        <CountProvider>
-          <App />
-        </CountProvider>
+        <ProfileProvider>
+          <CountProvider>
+            <App />
+          </CountProvider>
+        </ProfileProvider>
       </UserProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/babykicks/src/pages/count.js
+++ b/babykicks/src/pages/count.js
@@ -1,15 +1,48 @@
 import React, { useContext } from "react";
 import { CountContext } from "../contexts/count.context";
+import { ProfileContext } from "../contexts/profile.context";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import { Button } from "@mui/material";
+import { doc, arrayUnion, updateDoc } from "firebase/firestore";
+import { db } from "../utils/firebase/config";
 
 function Count() {
   const drawerWidth = 240;
   const { currentCount, setCurrentCount } = useContext(CountContext);
+  const { currentProfile } = useContext(ProfileContext);
+
+  //add time context to manage time
+  //start timer when currentCount is greater than 0.
+
+  //stop timer when handleSessionClick is clicked.
+
+  //add new session context to manage status
+
+  //useEffect to track time
 
   const handleCountClick = () => {
     setCurrentCount(currentCount + 1);
+  };
+
+  const handleSessionClick = async () => {
+    const start = Date.now();
+    const docRef = doc(db, "user", currentProfile.email);
+
+    //add new object onto firestore - time duration, start time
+    const newObject = {
+      time: start,
+      count: currentCount,
+    };
+    try {
+      updateDoc(docRef, {
+        history: arrayUnion(newObject),
+      });
+    } catch (error) {
+      console.log(`error in updating doc ${error}`);
+    }
+
+    //when session is clicked, set session status to false
   };
 
   return (
@@ -32,6 +65,7 @@ function Count() {
             Current baby count is {currentCount}
           </Typography>
           <Button onClick={handleCountClick}>Count kick</Button>
+          <Button onClick={handleSessionClick}>Save session</Button>
         </Box>
       </Box>
     </>


### PR DESCRIPTION
## Description

This PR introduces functionality to save each session's baby kick counts into Firestore in the form of an array against a user's profile. The baby kick count is associated with the time at which the session is saved and each session pushes a new object onto the Firestore history array. A new ProfileContext file is introduced to manage the user's profile state management. 

## Related Issue(s)

Closes issue #24

## Proposed Changes

1. Added a new `profile.context.jsx` to manage profile state
2. Updated `googleSignIn.js`
 -  Added `ProfileContext`so that when user signs in with `signInWithPopup`, `setCurrentProfile` is used to update the profile state using the retrieved data
 
3. Updated`index.js`file
- Added `ProfileProvider` into the main `index.js` file wrapping around `<CountProvider>` and `<App>`

4. Updated `count.js` file
- Imported `ProfileContext` to manage profile state
- Added a new 'Save session' button feature to allow babykicks count to be saved
- Imported `{ doc, arrayUnion, updateDoc }` from Firestore to handle the `handleSessionClick` function, allowing`newObject` to be added, which consists of `{time:start,count:currentCount}`, to the existing `history` on Firestore by using the `updateDoc` and `arrayUnion` method

## Screenshots 

![feature:#24](https://github.com/jasmine-ship-it/babykicks/assets/65453598/8bd55c1a-2a04-4f20-a633-4b25816cbd72)

## Additional Notes
- `count.js` file needs to introduce 'reset' and 'undo' options
- Duration between each kick needs to be added


