### PR TITLE
Reset count number

### DIFF
--- a/babykicks/src/contexts/profile.context.jsx
+++ b/babykicks/src/contexts/profile.context.jsx
@@ -18,3 +18,4 @@ export const ProfileProvider = ({ children }) => {
     <ProfileContext.Provider value={value}>{children}</ProfileContext.Provider>
   );
 };
+ 

--- a/babykicks/src/contexts/user.context.jsx
+++ b/babykicks/src/contexts/user.context.jsx
@@ -6,13 +6,7 @@ export const UserContext = createContext({
 });
 
 export const UserProvider = ({ children }) => {
-  const [currentUser, setCurrentUser] = useState({
-    name: "",
-    email: "",
-    displayPicture: "",
-    history: [],
-    serverTimestamp: "",
-  });
+  const [currentUser, setCurrentUser] = useState(null);
   const value = { currentUser, setCurrentUser };
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
 };

--- a/babykicks/src/pages/count.js
+++ b/babykicks/src/pages/count.js
@@ -38,6 +38,7 @@ function Count() {
       updateDoc(docRef, {
         history: arrayUnion(newObject),
       });
+      setCurrentCount(0);
     } catch (error) {
       console.log(`error in updating doc ${error}`);
     }


### PR DESCRIPTION
## Description

This PR resets count numbering back to zero when user clicks saves

## Related Issue(s)

Closes #26

## Proposed Changes

- Updated `count.js` file and added `setCurrentCount(0)` under `handleSessionClick` function.
