### PR TITLE
add basic ability to delete history items

### DIFF
--- a/babykicks/src/components/HistoryTable.js
+++ b/babykicks/src/components/HistoryTable.js
@@ -5,7 +5,9 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import Button from "@mui/material/Button";
 import { ProfileContext } from "../contexts/profile.context";
+import { useGoogleAuth } from "../hooks/useGoogleAuth";
 
 function createData(startTime, strength) {
   return { startTime, strength };
@@ -27,7 +29,15 @@ function formatDate(dateString) {
 }
 
 export const HistoryTable = () => {
-  const { currentProfile } = useContext(ProfileContext);
+  const { currentProfile, setCurrentProfile } = useContext(ProfileContext);
+
+  const { updateProfileHistory } = useGoogleAuth();
+
+  const handleDelete = async (index) => {
+    const updatedHistory = currentProfile.history.filter((_, i) => i !== index);
+    await updateProfileHistory(currentProfile, updatedHistory);
+    setCurrentProfile({ ...currentProfile, history: updatedHistory });
+  };
 
   const rows = currentProfile.history.map((item) =>
     createData(formatDate(item.startTime), item.strength)
@@ -55,7 +65,15 @@ export const HistoryTable = () => {
               </TableCell>
               <TableCell align="right">{row.startTime}</TableCell>
               <TableCell align="right">{row.strength}</TableCell>
-              <TableCell align="right">{""}</TableCell>
+              <TableCell align="right">
+                <Button
+                  variant="contained"
+                  color="secondary"
+                  onClick={() => handleDelete(index)}
+                >
+                  Delete
+                </Button>
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/babykicks/src/hooks/useGoogleAuth.js
+++ b/babykicks/src/hooks/useGoogleAuth.js
@@ -4,7 +4,7 @@ import { CountContext } from "../contexts/count.context";
 import { useContext } from "react";
 import { auth, provider, db } from "../utils/firebase/config";
 import { signInWithPopup, signOut } from "firebase/auth";
-import { doc, getDoc } from "firebase/firestore";
+import { doc, getDoc, setDoc } from "firebase/firestore";
 
 export const useGoogleAuth = () => {
   const { setCurrentUser } = useContext(UserContext);
@@ -74,9 +74,20 @@ export const useGoogleAuth = () => {
     }
   };
 
+  const updateProfileHistory = async (currentProfile, updatedHistory) => {
+    const docRef = doc(db, "user", currentProfile.email);
+    try {
+      await setDoc(docRef, { history: updatedHistory }, { merge: true });
+      console.log("Document successfully updated!");
+    } catch (error) {
+      console.error("Error updating document: ", error);
+    }
+  };
+
   return {
     handleSignInClick,
     handleSignOutClick,
     fetchProfileData,
+    updateProfileHistory,
   };
 };


### PR DESCRIPTION
## Description

Solves https://github.com/jasmine-ship-it/babykicks/issues/46 where deletion of a history item is desired.

## Related Issue(s)

- [x] This pull request addresses issue https://github.com/jasmine-ship-it/babykicks/issues/46

## Proposed Changes

- Added ability to updateProfileHistory to the existing `useGoogleAuth` hook. 
   - Added some console logging to the updateProfileHistory, so the success of this request can be monitored in the console..
- Exported by the hook and consumed by the `HistoryTable` component.

## Checklist

<!-- - [ ] Automated tests have been added or existing tests have been modified to cover the changes. (If not, please explain why not below). -->

- [ ] Documentation has been updated to reflect the changes (if applicable).
<!-- - [ ] The changes have been reviewed by at least one other developer. -->

## Screenshots (if applicable)

![Screenshot from 2024-07-05 12-22-52](https://github.com/jasmine-ship-it/babykicks/assets/23041901/64a9c7ba-098e-4340-82f7-62f398678d7c)

## Additional Notes (if applicable)

Add any additional notes or context about the changes made in this pull request.
