### PR TITLE
Feat/#46/ - add basic ability to delete history items

### DIFF
--- a/babykicks/src/components/HistoryTable.js
+++ b/babykicks/src/components/HistoryTable.js
@@ -1,0 +1,65 @@
+import React, { useContext } from "react";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import { ProfileContext } from "../contexts/profile.context";
+
+function createData(startTime, strength) {
+  return { startTime, strength };
+}
+
+function formatDate(dateString) {
+  const date = new Date(dateString);
+  const options = {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+    hour12: true,
+  };
+  return new Intl.DateTimeFormat("en-US", options).format(date);
+}
+
+export const HistoryTable = () => {
+  const { currentProfile } = useContext(ProfileContext);
+
+  const rows = currentProfile.history.map((item) =>
+    createData(formatDate(item.startTime), item.strength)
+  );
+
+  return (
+    <TableContainer>
+      <Table sx={{ maxWidth: 650, minWidth: 300 }} aria-label="history table">
+        <TableHead>
+          <TableRow>
+            <TableCell>Entry</TableCell>
+            <TableCell align="right">Start Time</TableCell>
+            <TableCell align="right">Strength</TableCell>
+            <TableCell align="right">Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, index) => (
+            <TableRow
+              key={`${row.startTime}${index}`}
+              sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+            >
+              <TableCell component="th" scope="row">
+                {index + 1}
+              </TableCell>
+              <TableCell align="right">{row.startTime}</TableCell>
+              <TableCell align="right">{row.strength}</TableCell>
+              <TableCell align="right">{""}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/babykicks/src/pages/history.js
+++ b/babykicks/src/pages/history.js
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import { UserContext } from "../contexts/user.context";
 import { ProfileContext } from "../contexts/profile.context";
+import { HistoryTable } from "../components/HistoryTable";
 
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
@@ -32,6 +33,7 @@ function History() {
           <Typography paragraph>History page</Typography>
           <Typography paragraph></Typography>
           {!currentUser && <SignedOutAlert />}
+          {currentUser && <HistoryTable />}
           {currentProfile && <LinePlot />}
         </Box>
       </Box>


### PR DESCRIPTION
## Description

Round 2 of https://github.com/jasmine-ship-it/babykicks/pull/50

Solves https://github.com/jasmine-ship-it/babykicks/issues/46 where deletion of a history item is desired.

This follows on from https://github.com/jasmine-ship-it/babykicks/pull/48 which adds the table UI

## Related Issue(s)

- [x] This pull request addresses issue https://github.com/jasmine-ship-it/babykicks/issues/46

## Proposed Changes

- Added ability to updateProfileHistory to the existing `useGoogleAuth` hook. 
   - Added some console logging to the updateProfileHistory, so the success of this request can be monitored in the console..
- Exported by the hook and consumed by the `HistoryTable` component.

## Checklist

<!-- - [ ] Automated tests have been added or existing tests have been modified to cover the changes. (If not, please explain why not below). -->

- [ ] Documentation has been updated to reflect the changes (if applicable).
<!-- - [ ] The changes have been reviewed by at least one other developer. -->

## Screenshots (if applicable)

![Screenshot from 2024-07-05 12-22-52](https://github.com/jasmine-ship-it/babykicks/assets/23041901/64a9c7ba-098e-4340-82f7-62f398678d7c)

## Additional Notes (if applicable)

Add any additional notes or context about the changes made in this pull request.
